### PR TITLE
Implement users.lookupByEmail

### DIFF
--- a/endpoints.json
+++ b/endpoints.json
@@ -1065,6 +1065,19 @@
     ]
   },
   {
+    "name": "users.lookupByEmail",
+    "proxy": true,
+    "return": "objects.User",
+    "json": "user",
+    "args": [
+      {
+        "name": "email",
+        "required": true,
+        "type": "string"
+      }
+    ]
+  },
+  {
     "name": "users.setActive"
   },
   {

--- a/server/proxyserver/proxyserver.go
+++ b/server/proxyserver/proxyserver.go
@@ -106,6 +106,7 @@ func (h *Handler) InstallHandlers(s *server.Server) {
 	s.Handle("users.identity", http.HandlerFunc(h.ProxyHandler))
 	s.Handle("users.info", http.HandlerFunc(h.ProxyHandler))
 	s.Handle("users.list", http.HandlerFunc(h.ProxyHandler))
+	s.Handle("users.lookupByEmail", http.HandlerFunc(h.ProxyHandler))
 	s.Handle("users.profile.get", http.HandlerFunc(h.ProxyHandler))
 	s.Handle("users.profile.set", http.HandlerFunc(h.mock.HandleUsersProfileSet))
 	s.Handle("users.setActive", http.HandlerFunc(h.mock.HandleUsersSetActive))

--- a/server/server.go
+++ b/server/server.go
@@ -89,6 +89,7 @@ func New(options ...Option) *Server {
 			"users.identity":          http.HandlerFunc(unimplemented),
 			"users.info":              http.HandlerFunc(unimplemented),
 			"users.list":              http.HandlerFunc(unimplemented),
+			"users.lookupByEmail":     http.HandlerFunc(unimplemented),
 			"users.profile.get":       http.HandlerFunc(unimplemented),
 			"users.profile.set":       http.HandlerFunc(unimplemented),
 			"users.setActive":         http.HandlerFunc(unimplemented),


### PR DESCRIPTION
Added [`users.lookupByEmail`](https://api.slack.com/methods/users.lookupByEmail), which is almost similar with [`users.info`](https://api.slack.com/methods/users.info).