### PR TITLE
Support Go module again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+go.sum
+/vendor
+/cmd/slaproxy/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ script:
   - make test
   - make check-diff
 go:
-  - 1.9.x
-  - 1.8.x
+  - 1.12.x
+  - 1.11.x
   - tip

--- a/cmd/slaproxy/go.mod
+++ b/cmd/slaproxy/go.mod
@@ -1,0 +1,15 @@
+module github.com/lestrrat-go/slack/cmd/slaproxy
+
+go 1.11
+
+require (
+	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
+	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
+	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
+	github.com/lestrrat-go/apache-logformat v2.0.3+incompatible
+	github.com/lestrrat-go/slack v0.0.0-20180726073730-18d3cce844c0
+	github.com/lestrrat-go/strftime v0.0.0-20190725011945-5c849dd2c51d // indirect
+	github.com/tebeka/strftime v0.1.3 // indirect
+)
+
+replace github.com/lestrrat-go/slack => ../../

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/lestrrat-go/slack
+
+go 1.11
+
+require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/gorilla/websocket v1.4.1
+	github.com/lestrrat-go/pdebug v0.0.0-20180220043849-39f9a71bcabe
+	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.4.0
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+)

--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-UNTRACKED=$(git ls-files --others --exclude-standard)
+UNTRACKED=$(git ls-files --others --exclude-standard | grep -v 'go.sum')
 DIFF=$(git diff)
 
 st=0


### PR DESCRIPTION
Support Go module. separate slack library and cmd/slapoxy for avoid unnecessary dependencies.

---

I was deleted `module` branch, so can't reopen #63 pull request :(
Sorry for confusing.